### PR TITLE
Update for Stardew Valley 1.6

### DIFF
--- a/ShippingBinSummary/manifest.json
+++ b/ShippingBinSummary/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "ShippingBinSummary",
   "Author": "Futro",
-  "Version": "1.0.1",
+  "Version": "1.1.0",
   "Description": "Shows a tooltip with the total price of items in Shipping Bin when you hover your mouse over it.",
   "UniqueID": "futro.ShippingBinSummary",
   "EntryDll": "ShippingBinSummary.dll",

--- a/ShippingBinSummary/packages.config
+++ b/ShippingBinSummary/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="4.1.1" targetFramework="net462" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="4.1.1" targetFramework="net6.0" />
 </packages>


### PR DESCRIPTION
Update to Stardew Valley 1.6, as described on https://stardewvalleywiki.com/Modding:Migrate_to_Stardew_Valley_1.6

It may need additional changes on .csproj, but this file is ignored in the repository.